### PR TITLE
Fix commons-io security vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -69,11 +69,11 @@
 		    <artifactId>commons-lang3</artifactId>
 		</dependency>
 		
-		<!-- https://mvnrepository.com/artifact/org.apache.commons/commons-io -->
+		<!-- https://mvnrepository.com/artifact/commons-io/commons-io -->
 		<dependency>
-		    <groupId>org.apache.commons</groupId>
+		    <groupId>commons-io</groupId>
 		    <artifactId>commons-io</artifactId>
-		    <version>1.3.2</version>
+		    <version>2.15.1</version>
 		</dependency>
 
 		


### PR DESCRIPTION
Updated commons-io from version 1.3.2 to 2.15.1:
- Fixed incorrect groupId (org.apache.commons -> commons-io)
- Updated to latest stable version to address security vulnerabilities
- No code changes required as commons-io is not actively used in the codebase